### PR TITLE
Fix @bsennblad name [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,4 +49,4 @@ extra:
   recipe-maintainers:
     - johanneskoester
     - bgruening
-    - bennblad
+    - bsennblad


### PR DESCRIPTION
Was a typo in the GitHub handle of @bsennblad listed in `recipe-maintainers`. So this fixes that typo.